### PR TITLE
simple Windows XP support for datadir

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -48,7 +48,8 @@ function Windows() {
 	}
 
 	this.datadir = function(appname) {
-		return process.env['LOCALAPPDATA']+"\\"+appname;
+    var appData = process.env['LOCALAPPDATA']||process.env['APPDATA']
+		return appData+"\\"+appname;
 	}
 }
     


### PR DESCRIPTION
Windows XP sadly does not have a simplistic LOCALAPPDATA env variable to use. It only has APPDATA and that should be used instead.

BTW: Windows XP does have a equivalent folder to LOCALAPPDATA as in Windows Vista and up, but its localized into the target OS language and thus difficult to code for. I think the simple APPDATA fallback is sufficient for most use-cases though.
