### PR TITLE
Respect env variables

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -33,7 +33,8 @@ function Linux () {
   }
 
   this.datadir = function (appname) {
-    return this.homedir() + '/.config/' + appname
+    var prefix = process.env['XDG_CONFIG_HOME'] || (this.homedir() + './config')
+    return prefix + '/' + appname
   }
 }
 
@@ -47,7 +48,8 @@ function FreeBSD () {
   }
 
   this.datadir = function (appname) {
-    return this.homedir() + '/.config/' + appname
+    var prefix = process.env['XDG_CONFIG_HOME'] || (this.homedir() + './config')
+    return prefix + '/' + appname
   }
 }
 

--- a/lib/path.js
+++ b/lib/path.js
@@ -25,7 +25,7 @@ function Darwin () {
 
 function Linux () {
   this.tempdir = function () {
-    return '/tmp'
+    return process.env['TMPDIR'] || '/tmp'
   }
 
   this.homedir = function () {
@@ -39,7 +39,7 @@ function Linux () {
 
 function FreeBSD () {
   this.tempdir = function () {
-    return '/tmp'
+    return process.env['TMPDIR'] || '/tmp'
   }
 
   this.homedir = function () {
@@ -53,7 +53,7 @@ function FreeBSD () {
 
 function SunOS () {
   this.tempdir = function () {
-    return '/tmp'
+    return process.env['TMPDIR'] || '/tmp'
   }
 
   this.homedir = function () {

--- a/test/path.test.js
+++ b/test/path.test.js
@@ -10,7 +10,7 @@ describe('path', function () {
       var tmpDir = path.tempdir()
       assert(tmpDir)
 
-      var testFile = 'TEST-path-ext-#{Date.now()}'
+      var testFile = 'TEST-path-ext-' + Date.now()
       testFile = path.join(tmpDir, testFile)
 
       var testString = 'SOME STRING'


### PR DESCRIPTION
Hi,

I think node-path-extra should respect env variables, notably `TMPDIR` and `XDG_CONFIG_HOME`. Is it OK for you?