### PR TITLE
lib/path: return empty string when home is undefined

### DIFF
--- a/lib/path.js
+++ b/lib/path.js
@@ -15,7 +15,7 @@ function Darwin () {
   }
 
   this.homedir = function () {
-    return process.env['HOME']
+    return process.env['HOME'] || ''
   }
 
   this.datadir = function (appname) {
@@ -29,7 +29,7 @@ function Linux () {
   }
 
   this.homedir = function () {
-    return process.env['HOME']
+    return process.env['HOME'] || ''
   }
 
   this.datadir = function (appname) {
@@ -44,7 +44,7 @@ function FreeBSD () {
   }
 
   this.homedir = function () {
-    return process.env['HOME']
+    return process.env['HOME'] || ''
   }
 
   this.datadir = function (appname) {
@@ -59,7 +59,7 @@ function SunOS () {
   }
 
   this.homedir = function () {
-    return process.env['HOME']
+    return process.env['HOME'] || ''
   }
 
   this.datadir = function (appname) {
@@ -73,7 +73,7 @@ function Windows () {
   }
 
   this.homedir = function () {
-    return process.env['USERPROFILE']
+    return process.env['USERPROFILE'] || ''
   }
 
   this.datadir = function (appname) {


### PR DESCRIPTION
I got into this issue when running node as a launchd daemon. In this case `HOME` environment variable isn't defined, so we are getting paths like `/undefined/Library/Application Support/...` as result.

This PR add guards to all home path variables, returning an empty string in case of undefined env vars.